### PR TITLE
Modifying ActorProducer to be able to use set methods on encapsulated variables of actors.

### DIFF
--- a/src/main/java/org/kurator/akka/actors/ConstantSource.java
+++ b/src/main/java/org/kurator/akka/actors/ConstantSource.java
@@ -4,10 +4,10 @@ import java.util.Collection;
 
 public class ConstantSource extends OneShot {
 
-    public Object value;
-    public Collection<Object> values;
+    private Object value;
+    private Collection<Object> values;
 
-    @Override
+	@Override
     public void fireOnce() throws Exception {
         
         if (value != null) {
@@ -17,5 +17,35 @@ public class ConstantSource extends OneShot {
                 broadcast(value);                    
             }
         }        
-    }
+    }    
+    
+    /**
+	 * @return the value
+	 */
+	public Object getValue() {
+		return value;
+	}
+
+	/**
+	 * @param value the value to set
+	 */
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
+	/**
+	 * @return the values
+	 */
+	public Collection<Object> getValues() {
+		return values;
+	}
+
+	/**
+	 * @param values the values to set
+	 */
+	public void setValues(Collection<Object> values) {
+		this.values = values;
+	}
+
+
 }


### PR DESCRIPTION
ISSUE: PURPOSE: Modifying ActorProducer so that it can check for set methods on private instance variables as well as attempting to directly set public instance variables, allowing actors to encapsulate their properties.  DESCRIPTION: Added an introspection check for a set method that follows the Java bean convention to the setting of actor properties in ActorProducer.  Also modified the ConstantSource actor to make value and values private with getter and setter methods.
